### PR TITLE
Enable debugging of blazor components

### DIFF
--- a/BlazorExample.Site/Properties/launchSettings.json
+++ b/BlazorExample.Site/Properties/launchSettings.json
@@ -12,6 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -20,6 +21,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "https://localhost:44383;http://localhost:55697",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
As per this [article ](https://visualstudiomagazine.com/articles/2021/06/10/rider-webassembly-debugging.aspx) rider support blazor web assembly debugging from v 2021.2

debugging works in vs and rider after taking the steps found here: https://docs.microsoft.com/en-us/aspnet/core/blazor/debug?view=aspnetcore-5.0&tabs=visual-studio

for now debugging is limited to:

- Google Chrome (version 70 or later) (default)

- Microsoft Edge (version 80 or later)

Mac OS is currently not supported 